### PR TITLE
geom_alt props

### DIFF
--- a/data/102/032/341/102032341.geojson
+++ b/data/102/032/341/102032341.geojson
@@ -849,6 +849,9 @@
         "wd:id":"Q334"
     },
     "wof:country":"SG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"084530ef275240506264dfb5177d3f91",
     "wof:hierarchy":[
         {
@@ -859,7 +862,7 @@
         }
     ],
     "wof:id":102032341,
-    "wof:lastmodified":1566644268,
+    "wof:lastmodified":1582355306,
     "wof:megacity":1,
     "wof:name":"Singapore",
     "wof:parent_id":85677041,

--- a/data/102/032/349/102032349.geojson
+++ b/data/102/032/349/102032349.geojson
@@ -209,6 +209,9 @@
         "qs_pg:id":338566
     },
     "wof:country":"SG",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccd9abe511442f316d106be0a0f95ae4",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":102032349,
-    "wof:lastmodified":1566644268,
+    "wof:lastmodified":1582355306,
     "wof:name":"Johor",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/202/033/421202033.geojson
+++ b/data/421/202/033/421202033.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"SG",
     "wof:created":1459010101,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2b301b9f995113b9e13a79e4e693651",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421202033,
-    "wof:lastmodified":1566644283,
+    "wof:lastmodified":1582355307,
     "wof:name":"Marina Centre",
     "wof:parent_id":85677041,
     "wof:placetype":"locality",

--- a/data/856/326/05/85632605.geojson
+++ b/data/856/326/05/85632605.geojson
@@ -987,6 +987,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1054,6 +1055,10 @@
     },
     "wof:country":"SG",
     "wof:country_alpha3":"SGP",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"57207c15e9ed2e97b1e151f125ec7452",
     "wof:hierarchy":[
         {
@@ -1074,7 +1079,7 @@
         "msa",
         "tam"
     ],
-    "wof:lastmodified":1566644272,
+    "wof:lastmodified":1582355307,
     "wof:name":"Singapore",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/326/05/85632605.geojson
+++ b/data/856/326/05/85632605.geojson
@@ -987,7 +987,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1079,7 +1078,7 @@
         "msa",
         "tam"
     ],
-    "wof:lastmodified":1582355307,
+    "wof:lastmodified":1583237370,
     "wof:name":"Singapore",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/857/842/03/85784203.geojson
+++ b/data/857/842/03/85784203.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":481808
     },
     "wof:country":"SG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3195a86ef0559631b110812e5d7f4d2",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644271,
+    "wof:lastmodified":1582355306,
     "wof:name":"Tanjung Puteri",
     "wof:parent_id":102032341,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.