### PR TITLE
sg concordances, placetype local, and more

### DIFF
--- a/data/172/983/413/1/1729834131.geojson
+++ b/data/172/983/413/1/1729834131.geojson
@@ -881,9 +881,11 @@
     "wof:concordances":{
         "gn:id":1880252,
         "gp:id":1062617,
+        "iso:code_pseudo":"SG",
         "qs_pg:id":807061,
         "wd:id":"Q334"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         1729834133,
         102032341,
@@ -912,7 +914,7 @@
         "msa",
         "tam"
     ],
-    "wof:lastmodified":1694497948,
+    "wof:lastmodified":1695886622,
     "wof:name":"Singapore",
     "wof:parent_id":1729834133,
     "wof:placetype":"county",

--- a/data/172/983/413/3/1729834133.geojson
+++ b/data/172/983/413/3/1729834133.geojson
@@ -879,9 +879,11 @@
     "wof:concordances":{
         "gn:id":1880252,
         "gp:id":1062617,
+        "iso:code_pseudo":"SG",
         "qs_pg:id":807061,
         "wd:id":"Q334"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         1729834131,
         102032341,
@@ -909,7 +911,7 @@
         "msa",
         "tam"
     ],
-    "wof:lastmodified":1694493236,
+    "wof:lastmodified":1695884671,
     "wof:name":"Singapore",
     "wof:parent_id":85632605,
     "wof:placetype":"region",

--- a/data/856/326/05/85632605.geojson
+++ b/data/856/326/05/85632605.geojson
@@ -1246,6 +1246,7 @@
         "hasc:id":"SG",
         "icao:code":"9V",
         "ioc:id":"SIN",
+        "iso:code":"SG",
         "iso:id":"SG-01",
         "itu:id":"SNG",
         "loc:id":"n79059023",
@@ -1261,6 +1262,7 @@
         "wk:page":"Singapore",
         "wmo:id":"SR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1729834133,
         1729834131,
@@ -1294,7 +1296,7 @@
         "msa",
         "tam"
     ],
-    "wof:lastmodified":1694639552,
+    "wof:lastmodified":1695881210,
     "wof:name":"Singapore",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.